### PR TITLE
#2 Compiled library with tests on Windows with MSVC

### DIFF
--- a/cmake/ProjectBuildFlags.cmake
+++ b/cmake/ProjectBuildFlags.cmake
@@ -3,20 +3,30 @@ add_library(dsa::build_flags ALIAS build_flags)
 
 target_compile_features(build_flags
     INTERFACE
-        c_std_23)
+        c_std_17)
 
-target_compile_options(build_flags
-    INTERFACE
-        -Werror
-        -Wall
-        -Wextra
-        -Wshadow
-        -Wcast-align
-        -Wunused
-        -Wpedantic
-        -Wconversion
-        -Wsign-conversion
-        -Wnull-dereference
-        -Wdouble-promotion
-        -Wformat=2
-        -Wimplicit-fallthrough)
+if (CMAKE_C_COMPILER_ID STREQUAL "MSVC")
+    target_compile_options(build_flags
+        INTERFACE
+            /W4             # Enable level 4 warnings
+            /WX             # Treat warnings as errors
+            /permissive-    # Enforce standard conformance
+    )
+else()
+    target_compile_options(build_flags
+        INTERFACE
+            -Werror
+            -Wall
+            -Wextra
+            -Wshadow
+            -Wcast-align
+            -Wunused
+            -Wpedantic
+            -Wconversion
+            -Wsign-conversion
+            -Wnull-dereference
+            -Wdouble-promotion
+            -Wformat=2
+            -Wimplicit-fallthrough
+    )
+endif()

--- a/include/dsa/numeric/lsqe.h
+++ b/include/dsa/numeric/lsqe.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <stdbool.h>
 #include <stddef.h>
 
 /**

--- a/include/dsa/sort/insertion_sort.h
+++ b/include/dsa/sort/insertion_sort.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <stdbool.h>
 #include <stddef.h>
 
 /**

--- a/src/numeric/lsqe.c
+++ b/src/numeric/lsqe.c
@@ -22,7 +22,7 @@ bool dsa_lsqe(const double *x, const double *y, const size_t size, double *a, do
         sumy += y[i];
     }
 
-    constexpr static double epsilon = 0.0001;
+    const double epsilon = 0.0001;
     const double denominator = ((double)size * sumx2 - sumx * sumx);
 
     if (fabs(denominator) < epsilon)


### PR DESCRIPTION
- Dropped C23 standard for C17 as MSVC does not support C23 standard.
- Adjusted code so that it compiles in C17 mode.