### PR TITLE
Moved extern "C" directives to headers from test files.

### DIFF
--- a/include/dsa/numeric/lsqe.h
+++ b/include/dsa/numeric/lsqe.h
@@ -1,5 +1,10 @@
 #pragma once
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #include <stdbool.h>
 #include <stddef.h>
 
@@ -23,3 +28,7 @@
  */
 
 bool dsa_lsqe(const double *x, const double *y, const size_t size, double *a, double *b);
+
+#if __cplusplus
+} // extern "C"
+#endif

--- a/include/dsa/numeric/root.h
+++ b/include/dsa/numeric/root.h
@@ -1,5 +1,10 @@
 #pragma once
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #include <stddef.h>
 
 /**
@@ -63,3 +68,7 @@ dsa_root_status dsa_find_root_newton(
     double *x,
     size_t *n,
     const double delta);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/include/dsa/search/binary_search.h
+++ b/include/dsa/search/binary_search.h
@@ -1,3 +1,10 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #include <stddef.h>
 
 /**
@@ -33,3 +40,7 @@ size_t dsa_binary_search(
     const size_t size,
     const size_t esize,
     int (*compare)(const void *key1, const void *key2));
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/include/dsa/sort/insertion_sort.h
+++ b/include/dsa/sort/insertion_sort.h
@@ -1,5 +1,10 @@
 #pragma once
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #include <stdbool.h>
 #include <stddef.h>
 
@@ -46,3 +51,7 @@ bool dsa_issort(
     const size_t size,
     const size_t esize,
     int (*compare)(const void *key1, const void *key2));
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/tests/numeric/test_lsqe.cpp
+++ b/tests/numeric/test_lsqe.cpp
@@ -4,10 +4,7 @@
 #include <array>
 #include <vector>
 
-extern "C"
-{
 #include "dsa/numeric/lsqe.h"
-}
 
 TEST_CASE("Least square estimation method for incorrect input values", "[lsqe]")
 {

--- a/tests/numeric/test_root.cpp
+++ b/tests/numeric/test_root.cpp
@@ -4,10 +4,7 @@
 #include <array>
 #include <cmath>
 
-extern "C"
-{
 #include "dsa/numeric/root.h"
-}
 
 namespace
 {

--- a/tests/search/test_binary_search.cpp
+++ b/tests/search/test_binary_search.cpp
@@ -6,10 +6,7 @@
 #include <cstring>
 #include <vector>
 
-extern "C"
-{
 #include "dsa/search/binary_search.h"
-}
 
 template <typename T>
 int ascending_compare(const void* a, const void* b)

--- a/tests/sort/test_insertion_sort.cpp
+++ b/tests/sort/test_insertion_sort.cpp
@@ -9,10 +9,7 @@
 #include <numeric>
 #include <random>
 
-extern "C"
-{
 #include "dsa/sort/insertion_sort.h"
-}
 
 struct CharWithIndex
 {


### PR DESCRIPTION
Since previously tests linked with the C library, extern "C" directive was needed in tests files. Now these directives were transferred to headers so that now it is enough to simply #include the header.